### PR TITLE
Pattern search for find

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,5 +9,5 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-
+    public static final String MESSAGE_INVALID_ARGUMENT_FORMAT = "Invalid argument format! \n%1$s";
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -17,9 +17,11 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
+    public static final String MESSAGE_INVALID_REGEX = "Regex supplied in invalid";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]"
+            + "Parameters: KEYWORD [MORE_KEYWORDS] "
             + "[" + PREFIX_PATTERN + "]\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -17,7 +17,7 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_INVALID_REGEX = "Regex supplied in invalid";
+    public static final String MESSAGE_INVALID_REGEX = "Regex supplied is invalid";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -34,7 +34,6 @@ public class FindCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -3,13 +3,11 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PATTERN;
 
-import seedu.address.commons.core.Messages;
-import seedu.address.logic.parser.ParserUtil;
-import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
-import seedu.address.model.person.Person;
-
 import java.util.function.Predicate;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,10 +1,15 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PATTERN;
 
 import seedu.address.commons.core.Messages;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.model.Model;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+
+import java.util.function.Predicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -16,18 +21,20 @@ public class FindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]"
+            + "[" + PREFIX_PATTERN + "]\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate<Person> predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate<Person> predicate) {
         this.predicate = predicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_PATTERN = new Prefix("p/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -28,24 +28,23 @@ public class FindCommandParser implements Parser<FindCommand> {
     public FindCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultiMap = ArgumentTokenizer.tokenize(args, PREFIX_PATTERN);
-        String nameString = argMultiMap.getPreamble();
+        String searchString = argMultiMap.getPreamble();
         if (argMultiMap.getValue(PREFIX_PATTERN).isPresent()) {
             try {
-                Pattern pattern = Pattern.compile(nameString, Pattern.CASE_INSENSITIVE);
+                Pattern pattern = Pattern.compile(searchString, Pattern.CASE_INSENSITIVE);
                 return new FindCommand(new NameContainsPatternPredicate(pattern));
             } catch (PatternSyntaxException pe) {
                 throw new ParseException(
                         String.format(MESSAGE_INVALID_ARGUMENT_FORMAT, MESSAGE_INVALID_REGEX));
             }
-        } else {
-            if (nameString.isEmpty()) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-            }
-            String[] nameKeywords = nameString.split("\\s+");
-
-            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
         }
+        if (searchString.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+        String[] nameKeywords = searchString.split("\\s+");
+
+        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,11 +1,14 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ARGUMENT_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.FindCommand.MESSAGE_INVALID_REGEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PATTERN;
 
 import java.util.Arrays;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -28,8 +31,14 @@ public class FindCommandParser implements Parser<FindCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_PATTERN);
         String nameString = argMultiMap.getPreamble();
         if (argMultiMap.getValue(PREFIX_PATTERN).isPresent()) {
-            Pattern pattern = Pattern.compile(nameString, Pattern.CASE_INSENSITIVE);
-            return new FindCommand(new NameContainsPatternPredicate(pattern));
+            try {
+                Pattern pattern = Pattern.compile(nameString, Pattern.CASE_INSENSITIVE);
+                return new FindCommand(new NameContainsPatternPredicate(pattern));
+            }
+            catch (PatternSyntaxException pe) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_ARGUMENT_FORMAT, MESSAGE_INVALID_REGEX));
+            }
         } else {
             if (nameString.isEmpty()) {
                 throw new ParseException(

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,16 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PATTERN;
 
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NameContainsPatternPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -19,15 +23,22 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        requireNonNull(args);
+        ArgumentMultimap argMultiMap =
+                ArgumentTokenizer.tokenize(args, PREFIX_PATTERN);
+        String nameString = argMultiMap.getPreamble();
+        if (argMultiMap.getValue(PREFIX_PATTERN).isPresent()) {
+            Pattern pattern = Pattern.compile(nameString, Pattern.CASE_INSENSITIVE);
+            return new FindCommand(new NameContainsPatternPredicate(pattern));
+        } else {
+            if (nameString.isEmpty()) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+            String[] nameKeywords = nameString.split("\\s+");
+
+            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
         }
-
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -27,8 +27,7 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultiMap =
-                ArgumentTokenizer.tokenize(args, PREFIX_PATTERN);
+        ArgumentMultimap argMultiMap = ArgumentTokenizer.tokenize(args, PREFIX_PATTERN);
         String nameString = argMultiMap.getPreamble();
         if (argMultiMap.getValue(PREFIX_PATTERN).isPresent()) {
             try {

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -34,8 +34,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             try {
                 Pattern pattern = Pattern.compile(nameString, Pattern.CASE_INSENSITIVE);
                 return new FindCommand(new NameContainsPatternPredicate(pattern));
-            }
-            catch (PatternSyntaxException pe) {
+            } catch (PatternSyntaxException pe) {
                 throw new ParseException(
                         String.format(MESSAGE_INVALID_ARGUMENT_FORMAT, MESSAGE_INVALID_REGEX));
             }

--- a/src/main/java/seedu/address/model/person/NameContainsPatternPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsPatternPredicate.java
@@ -18,8 +18,12 @@ public class NameContainsPatternPredicate implements Predicate<Person> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         NameContainsPatternPredicate that = (NameContainsPatternPredicate) o;
         return Objects.equals(pattern, that.pattern);
     }

--- a/src/main/java/seedu/address/model/person/NameContainsPatternPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsPatternPredicate.java
@@ -13,7 +13,7 @@ public class NameContainsPatternPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return pattern.matcher(person.getName().toString()).matches();
+        return pattern.matcher(person.getName().toString()).find();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsPatternPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsPatternPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+public class NameContainsPatternPredicate implements Predicate<Person> {
+    private final Pattern pattern;
+
+    public NameContainsPatternPredicate(Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return pattern.matcher(person.getName().toString()).matches();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NameContainsPatternPredicate that = (NameContainsPatternPredicate) o;
+        return Objects.equals(pattern, that.pattern);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pattern);
+    }
+}

--- a/src/main/java/seedu/address/model/person/NameContainsPatternPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsPatternPredicate.java
@@ -27,8 +27,8 @@ public class NameContainsPatternPredicate implements Predicate<Person> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        NameContainsPatternPredicate that = (NameContainsPatternPredicate) o;
-        return pattern.toString().equals(that.pattern.toString());
+        NameContainsPatternPredicate other = (NameContainsPatternPredicate) o;
+        return pattern.toString().equals(other.pattern.toString());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsPatternPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsPatternPredicate.java
@@ -4,6 +4,9 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+/**
+ * Tests that a {@code Person}'s {@code Name} matches the pattern given.
+ */
 public class NameContainsPatternPredicate implements Predicate<Person> {
     private final Pattern pattern;
 
@@ -25,7 +28,7 @@ public class NameContainsPatternPredicate implements Predicate<Person> {
             return false;
         }
         NameContainsPatternPredicate that = (NameContainsPatternPredicate) o;
-        return Objects.equals(pattern, that.pattern);
+        return pattern.toString().equals(that.pattern.toString());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/NameContainsPatternPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsPatternPredicate.java
@@ -20,15 +20,15 @@ public class NameContainsPatternPredicate implements Predicate<Person> {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object other) {
+        if (this == other) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (other == null || getClass() != other.getClass()) {
             return false;
         }
-        NameContainsPatternPredicate other = (NameContainsPatternPredicate) o;
-        return pattern.toString().equals(other.pattern.toString());
+        NameContainsPatternPredicate patternPredicate = (NameContainsPatternPredicate) other;
+        return pattern.toString().equals(patternPredicate.pattern.toString());
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -5,11 +5,13 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NameContainsPatternPredicate;
 
 public class FindCommandParserTest {
 
@@ -29,6 +31,12 @@ public class FindCommandParserTest {
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+
+        expectedFindCommand = new FindCommand(new NameContainsPatternPredicate(Pattern.compile("abc")));
+        assertParseSuccess(parser, "abc p/", expectedFindCommand);
+
+        expectedFindCommand = new FindCommand(new NameContainsPatternPredicate(Pattern.compile(".*")));
+        assertParseSuccess(parser, ".* p/", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/model/person/NameContainsPatternPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsPatternPredicateTest.java
@@ -1,10 +1,10 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -12,28 +12,26 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.PersonBuilder;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 public class NameContainsPatternPredicateTest {
 
-    final Pattern subStringPattern = Pattern.compile("et");
-    final Pattern matchAllPattern = Pattern.compile(".*");
-    final Pattern startsWithAPattern = Pattern.compile("^a");
-    final Pattern endsWithAPattern = Pattern.compile("a$");
-    final Pattern startsAndEndWithAPattern = Pattern.compile("^a.*a$");
+    public final Pattern subStringPattern = Pattern.compile("et");
+    public final Pattern matchAllPattern = Pattern.compile(".*");
+    public final Pattern startsWithAPattern = Pattern.compile("^a");
+    public final Pattern endsWithAPattern = Pattern.compile("a$");
+    public final Pattern startsAndEndWithAPattern = Pattern.compile("^a.*a$");
 
-    String[] nameArray = new String[] {
-            "alpha beta charlie",
-            "beta charlie",
-            "delta charlie alpha",
-            "beta beta beta",
-            "alpha alpha charlie delta",
-            "alpha  alpha    charlie delta"
+    private String[] nameArray = new String[] {
+        "alpha beta charlie",
+        "beta charlie",
+        "delta charlie alpha",
+        "beta beta beta",
+        "alpha alpha charlie delta",
+        "alpha  alpha    charlie delta"
     };
 
-    List<String> nameList = Arrays.stream(nameArray).collect(Collectors.toList());
+    private List<String> nameList = Arrays.stream(nameArray).collect(Collectors.toList());
 
-    List<String> filterList(List<String> nameList, Pattern pattern) {
+    public List<String> filterList(List<String> nameList, Pattern pattern) {
         return nameList.stream()
                 .map(name -> new PersonBuilder().withName(name).build())
                 .filter(new NameContainsPatternPredicate(pattern))

--- a/src/test/java/seedu/address/model/person/NameContainsPatternPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsPatternPredicateTest.java
@@ -49,7 +49,7 @@ public class NameContainsPatternPredicateTest {
         assertEquals(correctList, filterList(nameList, subStringPattern));
         correctList.clear();
 
-        assertEquals(filterList(nameList, matchAllPattern), nameList);
+        assertEquals(nameList, filterList(nameList, matchAllPattern));
 
         correctList.add("alpha beta charlie");
         correctList.add("alpha alpha charlie delta");

--- a/src/test/java/seedu/address/model/person/NameContainsPatternPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsPatternPredicateTest.java
@@ -1,0 +1,73 @@
+package seedu.address.model.person;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NameContainsPatternPredicateTest {
+
+    final Pattern subStringPattern = Pattern.compile("et");
+    final Pattern matchAllPattern = Pattern.compile(".*");
+    final Pattern startsWithAPattern = Pattern.compile("^a");
+    final Pattern endsWithAPattern = Pattern.compile("a$");
+    final Pattern startsAndEndWithAPattern = Pattern.compile("^a.*a$");
+
+    String[] nameArray = new String[] {
+            "alpha beta charlie",
+            "beta charlie",
+            "delta charlie alpha",
+            "beta beta beta",
+            "alpha alpha charlie delta",
+            "alpha  alpha    charlie delta"
+    };
+
+    List<String> nameList = Arrays.stream(nameArray).collect(Collectors.toList());
+
+    List<String> filterList(List<String> nameList, Pattern pattern) {
+        return nameList.stream()
+                .map(name -> new PersonBuilder().withName(name).build())
+                .filter(new NameContainsPatternPredicate(pattern))
+                .map(person -> person.getName().toString())
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void test_nameContainsPattern_returnsTrue() {
+        List<String> correctList = new ArrayList<>();
+
+        correctList.add("alpha beta charlie");
+        correctList.add("beta charlie");
+        correctList.add("beta beta beta");
+        assertEquals(correctList, filterList(nameList, subStringPattern));
+        correctList.clear();
+
+        assertEquals(filterList(nameList, matchAllPattern), nameList);
+
+        correctList.add("alpha beta charlie");
+        correctList.add("alpha alpha charlie delta");
+        correctList.add("alpha  alpha    charlie delta");
+        assertEquals(correctList, filterList(nameList, startsWithAPattern));
+        correctList.clear();
+
+        correctList.add("delta charlie alpha");
+        correctList.add("beta beta beta");
+        correctList.add("alpha alpha charlie delta");
+        correctList.add("alpha  alpha    charlie delta");
+        assertEquals(correctList, filterList(nameList, endsWithAPattern));
+        correctList.clear();
+
+        correctList.add("alpha alpha charlie delta");
+        correctList.add("alpha  alpha    charlie delta");
+        assertEquals(correctList, filterList(nameList, startsAndEndWithAPattern));
+    }
+}


### PR DESCRIPTION
Fixes #12 

Implementation only allows for simple word matching based on
substring provided. This is slightly cumbersome as it doesn't allow
find-grained searches.

For instance, it is not possible to search all person with names
starting with the alphabet 'a'

Including an option for the use of regular expressions allows the users
to have finer control over searching.

Lets create a predicate that makes use of regular expressions instead of
simple word matching.