### PR TITLE
Make adding tabs to DetailsPanel easier

### DIFF
--- a/src/main/java/seedu/address/ui/DetailsPanel.java
+++ b/src/main/java/seedu/address/ui/DetailsPanel.java
@@ -1,62 +1,33 @@
 package seedu.address.ui;
 
-import java.util.logging.Logger;
-
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
-import javafx.scene.control.Label;
-import javafx.scene.control.ListCell;
-import javafx.scene.control.ListView;
-import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import seedu.address.commons.core.DetailsPanelTab;
-import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.PersonEvent;
 
 public class DetailsPanel extends UiPart<Region> {
+
     private static final String FXML = "DetailsPanel.fxml";
-    private final Logger logger = LogsCenter.getLogger(DetailsPanel.class);
+
+    private final PersonDetailsTab personDetailsTab;
+    private final UpcomingEventsTab upcomingEventsTab;
 
     @FXML
-    private VBox upcomingEventsPane;
-
-    @FXML
-    private Label upcomingEventsTitle;
-
-    @FXML
-    private ListView<PersonEvent> upcomingDatesListView;
-
-    @FXML
-    private VBox personDetailsPane;
-
-    @FXML
-    private Label personDetailsTitle;
-
-    @FXML
-    private ListView<Person> personDetailsListView;
+    private VBox tabPlaceholder;
 
     /**
      * Creates a {@code DetailsPanel} with the given {@code ObservableList}s.
-     * @param upcomingDatesList A list of upcoming dates.
+     * @param upcomingEventsList A list of upcoming events.
      * @param detailedPerson A list containing a single {@code Person}.
      */
-    public DetailsPanel(ObservableList<PersonEvent> upcomingDatesList, ObservableList<Person> detailedPerson) {
+    public DetailsPanel(ObservableList<PersonEvent> upcomingEventsList, ObservableList<Person> detailedPerson) {
         super(FXML);
+        upcomingEventsTab = new UpcomingEventsTab(upcomingEventsList);
+        personDetailsTab = new PersonDetailsTab(detailedPerson);
         toggleTab(DetailsPanelTab.UPCOMING_EVENTS);
-        upcomingEventsTitle.setText("Upcoming Events");
-        upcomingDatesListView.setItems(upcomingDatesList);
-        upcomingDatesListView.setCellFactory(listView -> new UpcomingDatesListViewCell());
-
-        personDetailsTitle.setText("Contact Details");
-        personDetailsListView.setItems(detailedPerson);
-        personDetailsListView.setCellFactory(listView -> new PersonDetailsListViewCell());
-    }
-
-    private void setPaneVisibility(Pane pane, boolean isVisible) {
-        pane.setVisible(isVisible);
-        pane.setManaged(isVisible);
     }
 
     /**
@@ -66,48 +37,12 @@ public class DetailsPanel extends UiPart<Region> {
     public void toggleTab(DetailsPanelTab tab) {
         switch (tab) {
         case PERSON_DETAILS:
-            setPaneVisibility(personDetailsPane, true);
-            setPaneVisibility(upcomingEventsPane, false);
+            tabPlaceholder.getChildren().setAll(personDetailsTab.getRoot());
             break;
         case UPCOMING_EVENTS:
         default:
-            setPaneVisibility(upcomingEventsPane, true);
-            setPaneVisibility(personDetailsPane, false);
+            tabPlaceholder.getChildren().setAll(upcomingEventsTab.getRoot());
             break;
-        }
-    }
-
-    /**
-     * Custom {@code ListCell} that displays the graphics of an upcoming date.
-     */
-    class UpcomingDatesListViewCell extends ListCell<PersonEvent> {
-        @Override
-        protected void updateItem(PersonEvent personEvent, boolean empty) {
-            super.updateItem(personEvent, empty);
-
-            if (empty || personEvent == null) {
-                setGraphic(null);
-                setText(null);
-            } else {
-                setGraphic(new UpcomingDateCard(personEvent).getRoot());
-            }
-        }
-    }
-
-    /**
-     * Custom {@code ListCell} that displays the full details of a {@code Person}.
-     */
-    class PersonDetailsListViewCell extends ListCell<Person> {
-        @Override
-        protected void updateItem(Person person, boolean empty) {
-            super.updateItem(person, empty);
-
-            if (empty || person == null) {
-                setGraphic(null);
-                setText(null);
-            } else {
-                setGraphic(new PersonDetailsCard(person).getRoot());
-            }
         }
     }
 }

--- a/src/main/java/seedu/address/ui/PersonDetailsTab.java
+++ b/src/main/java/seedu/address/ui/PersonDetailsTab.java
@@ -1,0 +1,52 @@
+package seedu.address.ui;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import seedu.address.model.person.Person;
+
+public class PersonDetailsTab extends UiPart<Region> {
+
+    private static final String FXML = "PersonDetailsTab.fxml";
+
+    @FXML
+    private VBox personDetailsPane;
+
+    @FXML
+    private Label personDetailsTitle;
+
+    @FXML
+    private ListView<Person> personDetailsListView;
+
+    /**
+     * Creates a {@code PersonDetailsTab} with the given {@code ObservableList}.
+     * @param detailedPerson A list containing a single {@code Person}.
+     */
+    public PersonDetailsTab(ObservableList<Person> detailedPerson) {
+        super(FXML);
+        personDetailsTitle.setText("Contact Details");
+        personDetailsListView.setItems(detailedPerson);
+        personDetailsListView.setCellFactory(listView -> new PersonDetailsListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the full details of a {@code Person}.
+     */
+    class PersonDetailsListViewCell extends ListCell<Person> {
+        @Override
+        protected void updateItem(Person person, boolean empty) {
+            super.updateItem(person, empty);
+
+            if (empty || person == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new PersonDetailsCard(person).getRoot());
+            }
+        }
+    }
+}

--- a/src/main/java/seedu/address/ui/UpcomingEventsTab.java
+++ b/src/main/java/seedu/address/ui/UpcomingEventsTab.java
@@ -1,0 +1,52 @@
+package seedu.address.ui;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
+import seedu.address.model.person.PersonEvent;
+
+public class UpcomingEventsTab extends UiPart<Region> {
+
+    private static final String FXML = "UpcomingEventsTab.fxml";
+
+    @FXML
+    private VBox upcomingEventsPane;
+
+    @FXML
+    private Label upcomingEventsTitle;
+
+    @FXML
+    private ListView<PersonEvent> upcomingEventsListView;
+
+    /**
+     * Creates a {@code UpcomingEventsTab} with the given {@code ObservableList}.
+     * @param upcomingDatesList A list of upcoming events.
+     */
+    public UpcomingEventsTab(ObservableList<PersonEvent> upcomingDatesList) {
+        super(FXML);
+        upcomingEventsTitle.setText("Upcoming Events");
+        upcomingEventsListView.setItems(upcomingDatesList);
+        upcomingEventsListView.setCellFactory(listView -> new UpcomingEventsListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of an upcoming date.
+     */
+    class UpcomingEventsListViewCell extends ListCell<PersonEvent> {
+        @Override
+        protected void updateItem(PersonEvent personEvent, boolean empty) {
+            super.updateItem(personEvent, empty);
+
+            if (empty || personEvent == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new UpcomingDateCard(personEvent).getRoot());
+            }
+        }
+    }
+}

--- a/src/main/resources/view/DetailsPanel.fxml
+++ b/src/main/resources/view/DetailsPanel.fxml
@@ -1,25 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-    <VBox fx:id="upcomingEventsPane">
-        <Label fx:id="upcomingEventsTitle">
-            <padding>
-                <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
-            </padding>
-        </Label>
-        <ListView fx:id="upcomingDatesListView" VBox.vgrow="ALWAYS"/>
-    </VBox>
-    <VBox fx:id="personDetailsPane">
-        <Label fx:id="personDetailsTitle">
-            <padding>
-                <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
-            </padding>
-        </Label>
-        <ListView fx:id="personDetailsListView" VBox.vgrow="ALWAYS"/>
-    </VBox>
-</VBox>
+<VBox fx:id="tabPlaceholder" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" />

--- a/src/main/resources/view/PersonDetailsTab.fxml
+++ b/src/main/resources/view/PersonDetailsTab.fxml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox fx:id="personDetailsPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+    <Label fx:id="personDetailsTitle">
+        <padding>
+            <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+        </padding>
+    </Label>
+    <ListView fx:id="personDetailsListView" VBox.vgrow="ALWAYS"/>
+</VBox>

--- a/src/main/resources/view/UpcomingEventsTab.fxml
+++ b/src/main/resources/view/UpcomingEventsTab.fxml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ListView?>
+<?import javafx.scene.layout.VBox?>
+
+<VBox fx:id="upcomingEventsPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+    <Label fx:id="upcomingEventsTitle">
+        <padding>
+            <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+        </padding>
+    </Label>
+    <ListView fx:id="upcomingEventsListView" VBox.vgrow="ALWAYS"/>
+</VBox>


### PR DESCRIPTION
### Adding a new tab
Adding a new tab to DetailsPanel can now be done as follows:
1. Create a new `fxml` file for the new tab UI and its corresponding `java` file
2. Add an enum for the new tab to `DetailsPanelTab.java`
3. Pass relevant information to `DetailsPanel` on initialisation via `MainWindow` if necessary
4. Update `DetailsPanel.java#toggleTab()`, by adding your new tab to the switch case

Fixes #81 