### PR TITLE
Add `del-picture` command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddPictureCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPictureCommand.java
@@ -65,7 +65,7 @@ public class AddPictureCommand extends Command {
         UUID uuid = UUID.randomUUID();
         String ext = FileUtil.extractExtension(filePath);
         String newFileName = uuid.toString() + ext;
-        Path newFilePath = pictureDir.toAbsolutePath().resolve(newFileName);
+        Path newFilePath = pictureDir.resolve(newFileName);
 
         try {
             FileUtil.copyFile(filePath, newFilePath);

--- a/src/main/java/seedu/address/logic/commands/AddPictureCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPictureCommand.java
@@ -63,18 +63,6 @@ public class AddPictureCommand extends Command {
         ReadOnlyUserPrefs userPrefs = model.getUserPrefs();
         Path pictureDir = userPrefs.getPictureStorageDirPath();
 
-        Optional<Picture> oldPic = personToEdit.getPicture();
-        if (oldPic.isPresent()) {
-            try {
-                // We still let the user change picture even if the deletion did not go because it is not that crucial
-                // for the old picture to be deleted.
-                oldPic.get().deleteFile();
-            } catch (IOException e) {
-                logger.warning("Unable to delete original picture file for " + oldPic.toString());
-                logger.warning("IOException caught: " + e.getMessage());
-            }
-        }
-
         UUID uuid = UUID.randomUUID();
         String ext = FileUtil.extractExtension(filePath);
         String newFileName = uuid.toString() + ext;
@@ -88,7 +76,7 @@ public class AddPictureCommand extends Command {
         }
 
         Picture picture = new Picture(newFilePath);
-        Person editedPerson = personToEdit.withPicture(picture);
+        Person editedPerson = personToEdit.deletePicture().withPicture(picture);
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/logic/commands/AddPictureCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPictureCommand.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.logging.Logger;
 

--- a/src/main/java/seedu/address/logic/commands/Commands.java
+++ b/src/main/java/seedu/address/logic/commands/Commands.java
@@ -6,17 +6,22 @@ package seedu.address.logic.commands;
 public class Commands {
 
     public static String[] getAutoCompleteStrings() {
+
+        // In alphabetical order
         return new String[]{
                 AddCommand.COMMAND_WORD,
                 AddDateCommand.COMMAND_WORD,
                 AddGroupCommand.COMMAND_WORD,
                 AddMeetingCommand.COMMAND_WORD,
                 AddPictureCommand.COMMAND_WORD,
+                ChangeDebtCommand.COMMAND_WORD_ADD,
+                ChangeDebtCommand.COMMAND_WORD_SUBTRACT,
                 ClearCommand.COMMAND_WORD,
                 DeleteCommand.COMMAND_WORD,
-                DeleteGroupCommand.COMMAND_WORD,
                 DeleteDateCommand.COMMAND_WORD,
+                DeleteGroupCommand.COMMAND_WORD,
                 DeleteMeetingCommand.COMMAND_WORD,
+                DeletePictureCommand.COMMAND_WORD,
                 DetailsCommand.COMMAND_WORD,
                 EditCommand.COMMAND_WORD,
                 ExitCommand.COMMAND_WORD,
@@ -24,8 +29,6 @@ public class Commands {
                 HelpCommand.COMMAND_WORD,
                 ListCommand.COMMAND_WORD,
                 ThemeCommand.COMMAND_WORD,
-                ChangeDebtCommand.COMMAND_WORD_SUBTRACT,
-                ChangeDebtCommand.COMMAND_WORD_ADD,
                 ViewCommand.COMMAND_WORD
         };
     }

--- a/src/main/java/seedu/address/logic/commands/Commands.java
+++ b/src/main/java/seedu/address/logic/commands/Commands.java
@@ -7,7 +7,7 @@ public class Commands {
 
     public static String[] getAutoCompleteStrings() {
 
-        // In alphabetical order
+        // In alphabetical order for neatness
         return new String[]{
                 AddCommand.COMMAND_WORD,
                 AddDateCommand.COMMAND_WORD,

--- a/src/main/java/seedu/address/logic/commands/DeletePictureCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePictureCommand.java
@@ -19,7 +19,7 @@ public class DeletePictureCommand extends Command {
     public static final String COMMAND_WORD = "del-picture";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the picture of the person identified by the index number used in the displayed person list .\n"
+            + ": Deletes the picture of the person identified by the index number used in the displayed person list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 

--- a/src/main/java/seedu/address/logic/commands/DeletePictureCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePictureCommand.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,28 +42,20 @@ public class DeletePictureCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        // TODO: Perform picture deletion
-        Person p = lastShownList.get(targetIndex.getZeroBased());
-        Name name = p.getName();
+        Person personToEdit = lastShownList.get(targetIndex.getZeroBased());
+        Name name = personToEdit.getName();
 
-        Optional<Picture> pictureOptional = p.getPicture();
+        Optional<Picture> pictureOptional = personToEdit.getPicture();
         if (pictureOptional.isEmpty()) {
             throw new CommandException(String.format(MESSAGE_DELETE_PICTURE_NO_PICTURE_FOUND, name));
         }
 
-        // Try to delete the actual file
-        // try {
-        //     pictureOptional.get().deleteFile();
-        // } catch (IOException e) {
-        //     logger
-        // }
+        Person editedPerson = personToEdit.deletePicture();
 
-        // Remove binding of picture to
+        model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-
-
-
-        return new CommandResult(String.format(MESSAGE_DELETE_PICTURE_SUCCESS, p.getName()));
+        return new CommandResult(String.format(MESSAGE_DELETE_PICTURE_SUCCESS, name));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeletePictureCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePictureCommand.java
@@ -1,0 +1,75 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Picture;
+
+public class DeletePictureCommand extends Command {
+
+    public static final String COMMAND_WORD = "del-picture";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the picture of the person identified by the index number used in the displayed person list .\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_DELETE_PICTURE_SUCCESS = "Deleted picture for %1$s";
+
+    public static final String MESSAGE_DELETE_PICTURE_NO_PICTURE_FOUND = "No picture found for %1$s";
+
+    private final Index targetIndex;
+
+    public DeletePictureCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        // TODO: Perform picture deletion
+        Person p = lastShownList.get(targetIndex.getZeroBased());
+        Name name = p.getName();
+
+        Optional<Picture> pictureOptional = p.getPicture();
+        if (pictureOptional.isEmpty()) {
+            throw new CommandException(String.format(MESSAGE_DELETE_PICTURE_NO_PICTURE_FOUND, name));
+        }
+
+        // Try to delete the actual file
+        // try {
+        //     pictureOptional.get().deleteFile();
+        // } catch (IOException e) {
+        //     logger
+        // }
+
+        // Remove binding of picture to
+
+
+
+
+        return new CommandResult(String.format(MESSAGE_DELETE_PICTURE_SUCCESS, p.getName()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeletePictureCommand // instanceof handles nulls
+                && targetIndex.equals(((DeletePictureCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/DeletePictureCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeletePictureCommandParser.java
@@ -7,11 +7,12 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeletePictureCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-public class DeletePictureCommandParser implements Parser{
+public class DeletePictureCommandParser implements Parser {
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeletePictureCommand
      * and returns a DeletePictureCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform to the expected format
      */
     public DeletePictureCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/DeletePictureCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeletePictureCommandParser.java
@@ -7,7 +7,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeletePictureCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-public class DeletePictureCommandParser {
+public class DeletePictureCommandParser implements Parser{
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeletePictureCommand

--- a/src/main/java/seedu/address/logic/parser/DeletePictureCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeletePictureCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.DeletePictureCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class DeletePictureCommandParser {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeletePictureCommand
+     * and returns a DeletePictureCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public DeletePictureCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeletePictureCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePictureCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/InputParser.java
+++ b/src/main/java/seedu/address/logic/parser/InputParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteDateCommand;
 import seedu.address.logic.commands.DeleteGroupCommand;
 import seedu.address.logic.commands.DeleteMeetingCommand;
+import seedu.address.logic.commands.DeletePictureCommand;
 import seedu.address.logic.commands.DetailsCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -105,6 +106,9 @@ public class InputParser {
 
         case AddPictureCommand.COMMAND_WORD:
             return new AddPictureCommandParser().parse(arguments);
+
+        case DeletePictureCommand.COMMAND_WORD:
+            return new DeletePictureCommandParser().parse(arguments);
 
         case SetGoalCommand.COMMAND_WORD:
             return new SetGoalCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -170,8 +170,9 @@ public class Person {
     }
 
     /**
-     * Deletes the picture from person. The person is guaranteed to have {@code Picture} as null after
-     * running this method. Physical picture file may still remain if unable to remove from disk.
+     * Deletes the picture from person. The person is guaranteed to have a null {@code Picture} after
+     * execution of this method. Physical file may still remain if for some reason, the file cannot be deleted from
+     * disk.
      */
     public Person deletePicture() {
         if (picture == null) {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -3,7 +3,6 @@ package seedu.address.model.person;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -171,7 +171,7 @@ public class Person {
 
     /**
      * Deletes the picture from person. The person is guaranteed to have {@code Picture} as null after
-     * running this method.
+     * running this method. Physical picture file may still remain if unable to remove from disk.
      */
     public Person deletePicture() {
         if (picture == null) {
@@ -182,7 +182,7 @@ public class Person {
             // It is not that critical for the physical file of picture to get deleted so we just log the error.
             picture.deleteFile();
         } catch (IOException e) {
-            logger.warning("Unable to delete original picture file for " + toString());
+            logger.warning("Unable to delete physical picture file for " + toString());
             logger.warning("IOException caught: " + e.getMessage());
         }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,6 +2,8 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -10,8 +12,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.util.DateUtil;
 import seedu.address.model.tag.Tag;
 
@@ -22,14 +26,16 @@ import seedu.address.model.tag.Tag;
  */
 public class Person {
 
+    private static final Logger logger = LogsCenter.getLogger(Person.class);
+
     // Identity fields
     private final Name name;
     private final Phone phone;
     private final Email email;
     private final Birthday birthday;
-    private final Goal goal;
 
     // Data fields
+    private final Goal goal;
     private final Address address;
     private final Picture picture;
     private final Debt debt;
@@ -87,6 +93,10 @@ public class Person {
         return birthday;
     }
 
+    public Goal getGoal() {
+        return goal;
+    }
+
     public Address getAddress() {
         return address;
     }
@@ -101,10 +111,6 @@ public class Person {
 
     public Optional<Picture> getPicture() {
         return Optional.ofNullable(picture);
-    }
-
-    public Goal getGoal() {
-        return this.goal;
     }
 
     public Person withPicture(Picture picture) {
@@ -161,6 +167,26 @@ public class Person {
                 .max(LocalDate::compareTo)
                 .orElse(DateUtil.ZERO_DAY);
         return goal.getGoalDeadline(latestMeetingDate);
+    }
+
+    /**
+     * Deletes the picture from person. The person is guaranteed to have {@code Picture} as null after
+     * running this method.
+     */
+    public Person deletePicture() {
+        if (picture == null) {
+            return this;
+        }
+
+        try {
+            // It is not that critical for the physical file of picture to get deleted so we just log the error.
+            picture.deleteFile();
+        } catch (IOException e) {
+            logger.warning("Unable to delete original picture file for " + toString());
+            logger.warning("IOException caught: " + e.getMessage());
+        }
+
+        return withPicture(null);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Picture.java
+++ b/src/main/java/seedu/address/model/person/Picture.java
@@ -9,6 +9,7 @@ import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 public class Picture {
+
     public static final String[] ALLOWED_FILE_EXTENSIONS = {".png", ".jpeg", ".jpg"};
     public static final String ALLOWED_FILE_EXTENSIONS_STRING = String.join(", ", ALLOWED_FILE_EXTENSIONS);
 

--- a/src/test/java/seedu/address/logic/commands/AddPictureCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPictureCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_FILE_NOT_FOUND;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_FILE_EXTENSION;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
@@ -58,12 +59,6 @@ public class AddPictureCommandTest {
         pictureDir.delete();
     }
 
-    public void addPictureValidFileHelper(AddPictureCommand cmd) {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        String expectedMessage = String.format(AddPictureCommand.MESSAGE_ADD_PICTURE_SUCCESS, firstPerson.getName());
-        assertCommandSuccess(cmd, model, expectedMessage);
-    }
-
     @Test
     public void execute_addPictureInvalidFile_failure() {
         AddPictureCommand cmd;
@@ -78,12 +73,21 @@ public class AddPictureCommandTest {
                 Picture.ALLOWED_FILE_EXTENSIONS_STRING));
     }
 
+    public void testAddPicture(AddPictureCommand cmd) {
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        String expectedMessage = String.format(AddPictureCommand.MESSAGE_ADD_PICTURE_SUCCESS, firstPerson.getName());
+        assertCommandSuccess(cmd, model, expectedMessage);
+
+        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        assertTrue(Files.exists(editedPerson.getPicture().get().getFilePath()));
+    }
+
     @Test
     public void execute_addPictureValidFile_success() {
         AddPictureCommand cmd1 = new AddPictureCommand(INDEX_FIRST_PERSON, validPath);
         AddPictureCommand cmd2 = new AddPictureCommand(INDEX_FIRST_PERSON, validPathWithSpaces);
 
-        addPictureValidFileHelper(cmd1);
-        addPictureValidFileHelper(cmd2);
+        testAddPicture(cmd1);
+        testAddPicture(cmd2);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddPictureCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPictureCommandTest.java
@@ -7,9 +7,15 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
 
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -18,13 +24,39 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Picture;
 
 public class AddPictureCommandTest {
-    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     private final Path testFilesDir = Path.of("src", "test", "data", "PictureTest");
     private final Path fileNotFoundPath = testFilesDir.resolve("non_existant.jpeg");
     private final Path fileWrongExtPath = testFilesDir.resolve("invalid_format.txt");
     private final Path validPath = testFilesDir.resolve("picture.jpg");
     private final Path validPathWithSpaces = testFilesDir.resolve("picture with space.jpg");
+
+    private static UserPrefs userPrefs;
+    private final Model model = new ModelManager(getTypicalAddressBook(), userPrefs);
+
+    @BeforeAll
+    public static void initPictureDir() {
+        userPrefs = new UserPrefs();
+        Path tempPictureDir;
+        try {
+            tempPictureDir = Files.createTempDirectory("");
+            userPrefs.setPictureStorageDirPath(tempPictureDir);
+            tempPictureDir.toFile().deleteOnExit();
+        } catch (IOException ioe) {
+            throw new TestAbortedException("Unable to create temp directory for AddPictureCommandTest: " + ioe);
+        }
+    }
+
+    @AfterAll
+    public static void deletePictureDir() {
+        File pictureDir = userPrefs.getPictureStorageDirPath().toFile();
+
+        for(File file: pictureDir.listFiles()) {
+            file.delete();
+        }
+
+        pictureDir.delete();
+    }
 
     public void addPictureValidFileHelper(AddPictureCommand cmd) {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/AddPictureCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPictureCommandTest.java
@@ -26,13 +26,13 @@ import seedu.address.model.person.Picture;
 
 public class AddPictureCommandTest {
 
+    private static UserPrefs userPrefs;
+
     private final Path testFilesDir = Path.of("src", "test", "data", "PictureTest");
     private final Path fileNotFoundPath = testFilesDir.resolve("non_existant.jpeg");
     private final Path fileWrongExtPath = testFilesDir.resolve("invalid_format.txt");
     private final Path validPath = testFilesDir.resolve("picture.jpg");
     private final Path validPathWithSpaces = testFilesDir.resolve("picture with space.jpg");
-
-    private static UserPrefs userPrefs;
     private final Model model = new ModelManager(getTypicalAddressBook(), userPrefs);
 
     @BeforeAll
@@ -52,7 +52,7 @@ public class AddPictureCommandTest {
     public static void deletePictureDir() {
         File pictureDir = userPrefs.getPictureStorageDirPath().toFile();
 
-        for(File file: pictureDir.listFiles()) {
+        for (File file : pictureDir.listFiles()) {
             file.delete();
         }
 

--- a/src/test/java/seedu/address/logic/commands/DeletePictureCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeletePictureCommandTest.java
@@ -76,7 +76,7 @@ public class DeletePictureCommandTest {
             tmpFile = Files.createTempFile("picture", ".jpg");
             Files.copy(testPicPath, tmpFile, REPLACE_EXISTING);
         } catch (IOException ioe) {
-            throw new TestAbortedException("Unable to create test picture for DeletePictureCommand test");
+            throw new TestAbortedException("Unable to create test picture for DeletePictureCommand test: " + ioe);
         }
 
         Picture picture = new Picture(tmpFile);

--- a/src/test/java/seedu/address/logic/commands/DeletePictureCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeletePictureCommandTest.java
@@ -1,0 +1,111 @@
+package seedu.address.logic.commands;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.io.IOException;
+import java.nio.file.CopyOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.opentest4j.TestAbortedException;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.FileUtil;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Picture;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DeletePictureCommandTest {
+
+    // private static Path pictureDir;
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    private final Path testPicPath = Path.of("src", "test", "data", "PictureTest", "picture.jpg");
+
+    @Test
+    public void execute_invalidIndex_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        DeletePictureCommand cmd = new DeletePictureCommand(outOfBoundIndex);
+        assertCommandFailure(cmd, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_emptyPicture_throwsCommandException() {
+        Person p = model
+                .getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased())
+                .deletePicture();
+
+        DeletePictureCommand cmd = new DeletePictureCommand(INDEX_FIRST_PERSON);
+        assertCommandFailure(cmd, model,
+                String.format(DeletePictureCommand.MESSAGE_DELETE_PICTURE_NO_PICTURE_FOUND, p.getName()));
+    }
+
+    @Test
+    public void execute_validIndexAndPicture_success() {
+        Person person = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+        Path tmpFile;
+
+        try {
+            tmpFile = Files.createTempFile("picture", ".jpg");
+            Files.copy(testPicPath, tmpFile, REPLACE_EXISTING);
+        } catch (IOException ioe) {
+            throw new TestAbortedException("Unable to create test picture for DeletePictureCommand test");
+        }
+
+        Picture picture = new Picture(tmpFile);
+        Person personWithPicture = person.withPicture(picture);
+        model.setPerson(person, personWithPicture);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.setPerson(personWithPicture, person);
+
+        String expectedMessage = String.format(DeletePictureCommand.MESSAGE_DELETE_PICTURE_SUCCESS, person.getName());
+
+        DeletePictureCommand cmd = new DeletePictureCommand(INDEX_FIRST_PERSON);
+        assertCommandSuccess(cmd, model, expectedMessage, expectedModel);
+        assertFalse(Files.exists(tmpFile));
+    }
+
+    @Test
+    public void equals() {
+        DeletePictureCommand cmd1 = new DeletePictureCommand(INDEX_FIRST_PERSON);
+        DeletePictureCommand cmd2 = new DeletePictureCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertEquals(cmd1, cmd1);
+
+        // same values -> returns true
+        DeletePictureCommand cmd1Copy = new DeletePictureCommand(INDEX_FIRST_PERSON);
+        assertEquals(cmd1Copy, cmd1);
+
+        // different indexes -> returns false
+        assertNotEquals(cmd2, cmd1);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/DeletePictureCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeletePictureCommandTest.java
@@ -13,24 +13,17 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.io.IOException;
-import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.UUID;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.opentest4j.TestAbortedException;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.util.FileUtil;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
-import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Picture;
@@ -38,10 +31,8 @@ import seedu.address.model.person.Picture;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class DeletePictureCommandTest {
 
-    // private static Path pictureDir;
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-
     private final Path testPicPath = Path.of("src", "test", "data", "PictureTest", "picture.jpg");
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_invalidIndex_throwsCommandException() {

--- a/src/test/java/seedu/address/logic/parser/DeletePictureCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeletePictureCommandParserTest.java
@@ -7,7 +7,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeletePictureCommand;
 
 public class DeletePictureCommandParserTest {

--- a/src/test/java/seedu/address/logic/parser/DeletePictureCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeletePictureCommandParserTest.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeletePictureCommand;
+
+public class DeletePictureCommandParserTest {
+
+    private final DeletePictureCommandParser parser = new DeletePictureCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeletePictureCommand() {
+        assertParseSuccess(parser, "1", new DeletePictureCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "abc",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePictureCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
- Add `del-picture` command
- Wrote tests for it
- Used temp directories to store test image files instead of the actual `data` directory
- Store relative file names into the json data files for `add-picture` command

Fix #101 
Fix #121 