### PR TITLE
UI/UX improvements

### DIFF
--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -137,8 +137,7 @@ public class FileUtil {
                 current = magicNumber[i];
                 if (current != null && bytes[i] != current) {
                     break;
-                }
-                if (i == magicNumber.length - 1 && (current == null || current == bytes[i])) {
+                } else if (i == magicNumber.length - 1) {
                     return true;
                 }
             }

--- a/src/main/java/seedu/address/logic/commands/AddDateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddDateCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_DATE_BEFORE_BIRTHDAY;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -74,7 +73,7 @@ public class AddDateCommand extends Command {
         Person editedPerson = personToEdit.withDates(datesToEdit);
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList();
         model.updateUpcomingDates();
 
         return new CommandResult(String.format(MESSAGE_ADD_DATE_SUCCESS, editedPerson.getName()));

--- a/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGroupCommand.java
@@ -71,7 +71,7 @@ public class AddGroupCommand extends Command {
         } else {
             model.setGroup(groupName, group);
         }
-        model.updateFilteredPersonList(p -> group.getPersonNames().contains(p.getName()));
+        model.updateFilteredPersonList();
         return new CommandResult(String.format(MESSAGE_ADD_GROUP_SUCCESS, groupName));
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
@@ -6,7 +6,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIME;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -87,7 +86,7 @@ public class AddMeetingCommand extends Command {
         Person editedPerson = createEditedPerson(person, meeting);
 
         model.setPerson(person, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList();
 
         return new CommandResult(String.format(MESSAGE_ADD_MEETING_SUCCESS, editedPerson.getName()));
     }

--- a/src/main/java/seedu/address/logic/commands/AddPictureCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPictureCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_FILE_NOT_FOUND;
 import static seedu.address.commons.core.Messages.MESSAGE_FILE_TOO_BIG;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_FILE_EXTENSION;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_FILE_SIGNATURE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -79,7 +78,7 @@ public class AddPictureCommand extends Command {
         Person editedPerson = personToEdit.deletePicture().withPicture(picture);
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList();
 
         return new CommandResult(String.format(MESSAGE_ADD_PICTURE_SUCCESS, editedPerson.getName()));
     }

--- a/src/main/java/seedu/address/logic/commands/ChangeDebtCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ChangeDebtCommand.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
-
 import java.util.List;
 
 import seedu.address.commons.core.Messages;
@@ -58,7 +56,7 @@ public class ChangeDebtCommand extends Command {
             editedPerson = personToEdit.withDebt(Debt.subtract(currentDebt, debt));
         }
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList();
         if (isAdd) {
             return new CommandResult(String.format(MESSAGE_ADD_DEBT_SUCCESS, debt.toUi(), editedPerson.getName()));
         } else {

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -20,6 +20,7 @@ public class ClearCommand extends Command {
         model.setAddressBook(new AddressBook());
         model.updateUpcomingDates();
         model.updateDetailedPerson(null);
+        model.setCurrentGroup(null);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteDateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteDateCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -69,7 +68,7 @@ public class DeleteDateCommand extends Command {
         Person editedPerson = personToEdit.withDates(dates);
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList();
         model.updateUpcomingDates();
 
         return new CommandResult(String.format(MESSAGE_DELETE_DATE_SUCCESS, editedPerson.getName()));

--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -40,7 +40,7 @@ public class DeleteGroupCommand extends Command {
         }
 
         model.deleteGroup(group);
-        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList();
 
         return new CommandResult(String.format(MESSAGE_DELETE_GROUP_SUCCESS, groupName));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteMeetingCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +63,7 @@ public class DeleteMeetingCommand extends Command {
         Person editedPerson = personToEdit.withMeetings(meetings);
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList();
 
         return new CommandResult(String.format(MESSAGE_DELETE_MEETING_SUCCESS, editedPerson.getName()));
     }

--- a/src/main/java/seedu/address/logic/commands/DeletePictureCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePictureCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 import java.util.Optional;
@@ -53,7 +52,7 @@ public class DeletePictureCommand extends Command {
         Person editedPerson = personToEdit.deletePicture();
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList();
 
         return new CommandResult(String.format(MESSAGE_DELETE_PICTURE_SUCCESS, name));
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -114,7 +113,7 @@ public class EditCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList();
         model.updateUpcomingDates();
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson.toUi()));
     }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_GROUP;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Optional;
 
@@ -36,7 +35,8 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         if (this.name.isEmpty()) {
-            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            model.setCurrentGroup(null);
+            model.updateFilteredPersonList();
             return new CommandResult(MESSAGE_SUCCESS_DEFAULT);
         } else {
             Group group = model.getGroupMap().get(name.get());
@@ -46,7 +46,7 @@ public class ListCommand extends Command {
 
             //this will cause the UI to select the group cell.
             model.setGroup(group.getName(), group);
-            model.updateFilteredPersonList(p -> group.getPersonNames().contains(p.getName()));
+            model.updateFilteredPersonList();
             return new CommandResult(String.format(MESSAGE_SUCCESS_GROUP, group.getName()));
         }
     }

--- a/src/main/java/seedu/address/logic/commands/SetGoalCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetGoalCommand.java
@@ -53,7 +53,7 @@ public class SetGoalCommand extends Command {
         Goal newGoal = new Goal(this.frequency);
         Person editedPerson = personToEdit.withGoal(newGoal);
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList();
         model.updateUpcomingDates();
 
         return new CommandResult(String.format(MESSAGE_ADD_GOAL_SUCCESS,

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -104,6 +104,16 @@ public interface Model {
      */
     void setGroup(Name groupName, Group editedGroup);
 
+    /**
+     * Updates the current group to be displayed with the provided {@code currentGroup}.
+     */
+    void setCurrentGroup(Group currentGroup);
+
+    /**
+     * Returns a predicate that filters {@code Person}s to include only those in {@code currentGroup}
+     */
+    Predicate<Person> getCurrentGroupPredicate();
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
@@ -112,6 +122,11 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Updates the filter of the filtered person list to filter by all persons, or persons in {@code currentGroup}.
+     */
+    void updateFilteredPersonList();
 
     /**
      * Returns an unmodifiable view of the filtered group list

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -32,6 +32,7 @@ public class ModelManager implements Model {
     private final ObservableList<PersonEvent> upcomingDates;
     private final ObservableList<Person> detailedPerson;
     private final ObservableList<PersonStreak> personStreaks;
+    private Group currentGroup;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -49,6 +50,7 @@ public class ModelManager implements Model {
         upcomingDates = this.addressBook.getUpcomingDates();
         detailedPerson = FXCollections.observableArrayList();
         personStreaks = this.addressBook.getPersonStreaks();
+        currentGroup = null;
     }
 
     public ModelManager() {
@@ -131,6 +133,7 @@ public class ModelManager implements Model {
 
     @Override
     public void addGroup(Group group) {
+        setCurrentGroup(group);
         addressBook.addGroup(group);
     }
 
@@ -142,12 +145,26 @@ public class ModelManager implements Model {
 
     @Override
     public void deleteGroup(Group target) {
+        if (currentGroup.isSameGroup(target)) {
+            setCurrentGroup(null);
+        }
         addressBook.removeGroup(target);
     }
 
     @Override
     public void setGroup(Name groupName, Group editedGroup) {
+        setCurrentGroup(editedGroup);
         addressBook.setGroup(groupName, editedGroup);
+    }
+
+    @Override
+    public void setCurrentGroup(Group currentGroup) {
+        this.currentGroup = currentGroup;
+    }
+
+    @Override
+    public Predicate<Person> getCurrentGroupPredicate() {
+        return p -> currentGroup.getPersonNames().contains(p.getName());
     }
 
     //=========== Filtered Person List Accessors =============================================================
@@ -165,6 +182,15 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredPersonList() {
+        if (currentGroup != null) {
+            filteredPersons.setPredicate(getCurrentGroupPredicate());
+        } else {
+            filteredPersons.setPredicate(PREDICATE_SHOW_ALL_PERSONS);
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/ui/GroupListPanel.java
+++ b/src/main/java/seedu/address/ui/GroupListPanel.java
@@ -6,6 +6,7 @@ import javafx.application.Platform;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableMap;
 import javafx.fxml.FXML;
+import javafx.geometry.Insets;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
@@ -54,7 +55,9 @@ public class GroupListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new Label(groupName.fullName));
+                Label label = new Label(groupName.fullName);
+                label.setPadding(new Insets(10));
+                setGraphic(label);
             }
         }
     }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -20,14 +20,14 @@
             <padding>
               <Insets bottom="5" left="15" right="5" top="5" />
             </padding>
-            <HBox alignment="CENTER_LEFT" spacing="5">
+            <HBox alignment="TOP_LEFT" spacing="5">
               <Label fx:id="id" styleClass="cell_big_label">
                 <minWidth>
                   <!-- Ensures that the label text is never truncated -->
                   <Region fx:constant="USE_PREF_SIZE" />
                 </minWidth>
               </Label>
-              <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
+              <Label fx:id="name" styleClass="cell_big_label" text="\$first" wrapText="true" />
             </HBox>
             <FlowPane fx:id="tags" />
             <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -164,6 +164,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setCurrentGroup(Group currentGroup) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Predicate<Person> getCurrentGroupPredicate() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }
@@ -175,6 +185,11 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
- Retain current list of people when executing commands that shouldn't toggle the people displayed (Fixes #202)
  - i.e. `add-date`, `del-meeting`, `add-debt` should not reset the list of people back to the full list if they are currently viewing a certain group
  - Calling `updateFilteredPersonList` with no params will now check if there is a `currentGroup` to be displayed, and if so uses the appropriate predicate. Else it uses the predicate to show all persons.
- Add text wrap for long names (Fixes #164)
- Add padding to group names in group list panel (Fixes #129)
